### PR TITLE
Change order of filepaths in webpack config

### DIFF
--- a/rcahmw/webpack/webpack.common.js
+++ b/rcahmw/webpack/webpack.common.js
@@ -70,8 +70,8 @@ module.exports = () => {
             // order is important! Arches core files are overwritten by project files, project files are overwritten by archesApplication files
             const javascriptRelativeFilepathToAbsoluteFilepathLookup = {
                 ...archesCoreJavascriptRelativeFilepathToAbsoluteFilepathLookup,
-                ...projectJavascriptRelativeFilepathToAbsoluteFilepathLookup,
-                ...archesApplicationsJavascriptRelativeFilepathToAbsoluteFilepathLookup
+                ...archesApplicationsJavascriptRelativeFilepathToAbsoluteFilepathLookup,
+                ...projectJavascriptRelativeFilepathToAbsoluteFilepathLookup
             };
 
             // END create JavaScript filepath lookups


### PR DESCRIPTION
This means that webpack will prioritise js files from the project rather than apps, in line with new projects from Arches 7.6 onwards. 

Closes https://github.com/k-int/arches-rcahmw/issues/4